### PR TITLE
Stable 2.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ git push origin HEAD:stable-2.14 || echo not pushed
 git submodule foreach 'curl -s -o change.json https://gerrit-review.googlesource.com/changes/?q=project:plugins/$name+status:open+branch:stable-2.14+merge+branch\&n=1\&o=CURRENT_REVISION\&o=DOWNLOAD_COMMANDS || echo no change'
 git submodule foreach 'tail --lines=+2 change.json | jq -r ".[0].revisions[].fetch.http.commands.Checkout" > change.fetch || echo no command'
 git submodule foreach 'chmod +x change.fetch && ./change.fetch || echo no fetch'
+git submodule foreach 'git log -n 1 || echo no log'
 git submodule foreach 'bazel clean --expunge && bazel build $name || echo no standalone'
 git submodule foreach 'bazel test //... || echo no tests'
 git submodule foreach 'rm change.json change.fetch && git checkout stable-2.14 || echo no files'

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ git submodule foreach 'curl -s -o change.json https://gerrit-review.googlesource
 git submodule foreach 'tail --lines=+2 change.json | jq -r ".[0].revisions[].fetch.http.commands.Checkout" > change.fetch || echo no command'
 git submodule foreach 'chmod +x change.fetch && ./change.fetch || echo no fetch'
 git submodule foreach 'bazel clean --expunge && bazel build $name || echo no standalone'
-git submodule foreach 'bazel test //... || echo no standalone'
-git submodule foreach 'rm change.json change.fetch && git checkout stable-2.14'
+git submodule foreach 'bazel test //... || echo no tests'
+git submodule foreach 'rm change.json change.fetch && git checkout stable-2.14 || echo no files'
 ```
 
 ## Review bazlets upgrade change

--- a/README.md
+++ b/README.md
@@ -49,3 +49,10 @@ git submodule foreach 'bazel test //... || echo no standalone'
 git submodule foreach 'rm change.json change.fetch && git checkout stable-2.14'
 ```
 
+## Review bazlets upgrade change
+### -works with trailing commands above
+
+```
+git submodule foreach 'curl -s -o change.json https://gerrit-review.googlesource.com/changes/?q=project:plugins/$name+status:open+branch:stable-2.14+Upgrade+bazlets\&n=1\&o=CURRENT_REVISION\&o=DOWNLOAD_COMMANDS || echo no change'
+```
+


### PR DESCRIPTION
This new PR should only bring the diffs from the 3 README commits listed in it. That patch should solely be made of the latest README.md changes coming from stable-2.14 (adapted here from 2.14 to 2.15).

This should also correspond to the actual parent commits used in this merge commit. These parents are the commits from the dpursehouse branches tips as the remote. When I compare this change with the latter, I only see such README-related (trivial) diffs, as expected from this PR, thus no submodule diffs at all. If that is not the case while reviewing this PR, thank you for also sharing the method that shows otherwise.

Based on the outcome of this PR, I would like to merge this new stable-2.15 up to 2.16 then master, so that amended README can be used up there as well. (At least this would be my proposal.)