### PR TITLE
README: Replace stable-2.15 usage with master's

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This project contains several submodules, each of which is a Gerrit plugin.
 To update the bazlets revision on all plugins:
 
 ```
-git submodule foreach  ../update-bazlets.py -r 6d3fd710ea4ca44805bb8c858d72b53bd3a500f3 -b stable-2.15 -v 2.15.5
-git submodule foreach 'git push origin HEAD:refs/for/stable-2.15 || echo not pushed'
+git submodule foreach  ../update-bazlets.py -r 60bb597a9b8b0700334f8845ca61a7abc604ffcc -b master -v latest
+git submodule foreach 'git push origin HEAD:refs/for/master || echo not pushed'
 ```
 
 ## Format code
@@ -16,7 +16,7 @@ git submodule foreach 'git push origin HEAD:refs/for/stable-2.15 || echo not pus
 ```
 git submodule foreach 'git ls-files | grep java$ | xargs google-java-format -i'
 git submodule foreach 'git commit -a -m "Format all Java files with google-java-format" || echo nothing to commit'
-git submodule foreach 'git push origin HEAD:refs/for/stable-2.15 || echo not pushed'
+git submodule foreach 'git push origin HEAD:refs/for/master || echo not pushed'
 ```
 
 ## Format build files
@@ -24,6 +24,6 @@ git submodule foreach 'git push origin HEAD:refs/for/stable-2.15 || echo not pus
 ```
 git submodule foreach 'git ls-files | grep "WORKSPACE\|BUILD\|\.bzl$" | xargs buildifier -mode=fix'
 git submodule foreach 'git commit -a -m "Format all Bazel build files with buildifier" || echo nothing to commit'
-git submodule foreach 'git push origin HEAD:refs/for/stable-2.15 || echo not pushed'
+git submodule foreach 'git push origin HEAD:refs/for/master || echo not pushed'
 ```
 


### PR DESCRIPTION
This PR should be explained through its single commit's message. It is about the fact (AFAIK) that the master branch didn't have its own version of the README yet. Once this PR gets merged, if suitable enough, we should then be able to complete the merge up from stable-2.16. The latter branch currently has PR #7 open for that ongoing purpose.