### PR TITLE
Merge branch 'stable-2.16'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # LC_COLLATE=C sort
+/batch
+/task
 /.idea/
 /gerrit-plugins.iml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# LC_COLLATE=C sort
+/.idea/
+/gerrit-plugins.iml

--- a/.gitmodules
+++ b/.gitmodules
@@ -85,3 +85,6 @@
 [submodule "task"]
 	path = task
 	url = https://gerrit-review.googlesouce.com/plugins/task
+[submodule "serviceuser"]
+	path = serviceuser
+	url = https://gerrit-review.googlesource.com/plugins/serviceuser

--- a/.gitmodules
+++ b/.gitmodules
@@ -91,3 +91,6 @@
 [submodule "emoticons"]
 	path = emoticons
 	url = https://gerrit-review.googlesource.com/plugins/emoticons
+[submodule "reviewassistant"]
+	path = reviewassistant
+	url = https://gerrit-review.googlesource.com/plugins/reviewassistant

--- a/.gitmodules
+++ b/.gitmodules
@@ -88,3 +88,6 @@
 [submodule "serviceuser"]
 	path = serviceuser
 	url = https://gerrit-review.googlesource.com/plugins/serviceuser
+[submodule "emoticons"]
+	path = emoticons
+	url = https://gerrit-review.googlesource.com/plugins/emoticons

--- a/.gitmodules
+++ b/.gitmodules
@@ -85,3 +85,6 @@
 [submodule "batch"]
 	path = batch
 	url = https://gerrit-review.googlesource.com/plugins/batch
+[submodule "serviceuser"]
+	path = serviceuser
+	url = https://gerrit-review.googlesource.com/plugins/serviceuser

--- a/.gitmodules
+++ b/.gitmodules
@@ -85,3 +85,6 @@
 [submodule "messageoftheday"]
 	path = messageoftheday
 	url = https://gerrit-review.googlesource.com/plugins/messageoftheday
+[submodule "serviceuser"]
+	path = serviceuser
+	url = https://gerrit-review.googlesource.com/plugins/serviceuser

--- a/.gitmodules
+++ b/.gitmodules
@@ -82,6 +82,3 @@
 [submodule "gc-conductor"]
 	path = gc-conductor
 	url = https://gerrit-review.googlesource.com/plugins/gc-conductor
-[submodule "batch"]
-	path = batch
-	url = https://gerrit-review.googlesource.com/plugins/batch

--- a/.gitmodules
+++ b/.gitmodules
@@ -84,7 +84,7 @@
 	url = https://gerrit-review.googlesource.com/plugins/gc-conductor
 [submodule "task"]
 	path = task
-	url = https://gerrit-review.googlesouce.com/plugins/task
+	url = https://gerrit-review.googlesource.com/plugins/task
 [submodule "serviceuser"]
 	path = serviceuser
 	url = https://gerrit-review.googlesource.com/plugins/serviceuser

--- a/.gitmodules
+++ b/.gitmodules
@@ -37,9 +37,6 @@
 [submodule "oauth"]
 	path = oauth
 	url = https://gerrit-review.googlesource.com/plugins/oauth
-[submodule "owners"]
-	path = owners
-	url = https://gerrit-review.googlesource.com/plugins/owners
 [submodule "quota"]
 	path = quota
 	url = https://gerrit-review.googlesource.com/plugins/quota
@@ -64,9 +61,6 @@
 [submodule "webhooks"]
 	path = webhooks
 	url = https://gerrit-review.googlesource.com/plugins/webhooks
-[submodule "its-base"]
-	path = its-base
-	url = https://gerrit-review.googlesource.com/plugins/its-base
 [submodule "project-group-structure"]
 	path = project-group-structure
 	url = https://gerrit-review.googlesource.com/plugins/project-group-structure
@@ -79,9 +73,6 @@
 [submodule "rate-limiter"]
 	path = rate-limiter
 	url = https://gerrit-review.googlesource.com/plugins/rate-limiter
-[submodule "autosubmitter"]
-	path = autosubmitter
-	url = https://gerrit-review.googlesource.com/plugins/autosubmitter
 [submodule "messageoftheday"]
 	path = messageoftheday
 	url = https://gerrit-review.googlesource.com/plugins/messageoftheday

--- a/.gitmodules
+++ b/.gitmodules
@@ -82,3 +82,6 @@
 [submodule "gc-conductor"]
 	path = gc-conductor
 	url = https://gerrit-review.googlesource.com/plugins/gc-conductor
+[submodule "batch"]
+	path = batch
+	url = https://gerrit-review.googlesource.com/plugins/batch

--- a/.gitmodules
+++ b/.gitmodules
@@ -82,3 +82,6 @@
 [submodule "gc-conductor"]
 	path = gc-conductor
 	url = https://gerrit-review.googlesource.com/plugins/gc-conductor
+[submodule "task"]
+	path = task
+	url = https://gerrit-review.googlesouce.com/plugins/task

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+pygerrit2 = "*"
+
+[requires]
+python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,70 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "0b727352c4621972a63dd3b2bf9476fb95b1492cb2d84be169b49e7793cb6da0"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
+                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
+            ],
+            "version": "==2018.11.29"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
+                "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
+            ],
+            "version": "==2.7"
+        },
+        "pbr": {
+            "hashes": [
+                "sha256:f59d71442f9ece3dffc17bc36575768e1ee9967756e6b6535f0ee1f0054c3d68",
+                "sha256:f6d5b23f226a2ba58e14e49aa3b1bfaf814d0199144b95d78458212444de1387"
+            ],
+            "version": "==5.1.1"
+        },
+        "pygerrit2": {
+            "hashes": [
+                "sha256:c9880e07693bd6ef370454e3f037568b9d330b9e9f26853151f2d83264df5ed4"
+            ],
+            "index": "pypi",
+            "version": "==2.0.8"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:65b3a120e4329e33c9889db89c80976c5272f56ea92d3e74da8a463992e3ff54",
+                "sha256:ea881206e59f41dbd0bd445437d792e43906703fff75ca8ff43ccdb11f33f263"
+            ],
+            "version": "==2.20.1"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
+                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+            ],
+            "version": "==1.24.1"
+        }
+    },
+    "develop": {}
+}

--- a/README.md
+++ b/README.md
@@ -27,3 +27,13 @@ git submodule foreach 'git commit -a -m "Format all Bazel build files with build
 git submodule foreach 'git push origin HEAD:refs/for/stable-2.14 || echo not pushed'
 ```
 
+## Update submodules
+
+```
+git submodule foreach 'git checkout -t origin/stable-2.14 || echo execute only once or so'
+git submodule foreach 'git checkout stable-2.14 || echo no stable-2.14 branch'
+git submodule foreach 'git pull || echo dirty status?'
+git commit -a -m "Update submodules based on each latest branch tip" || echo cannot add or commit
+git push origin HEAD:stable-2.14 || echo not pushed
+```
+

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ git push origin HEAD:stable-2.14 || echo not pushed
 git submodule foreach 'curl -s -o change.json https://gerrit-review.googlesource.com/changes/?q=project:plugins/$name+status:open+branch:stable-2.14+merge+branch\&n=1\&o=CURRENT_REVISION\&o=DOWNLOAD_COMMANDS || echo no change'
 git submodule foreach 'tail --lines=+2 change.json | jq -r ".[0].revisions[].fetch.http.commands.Checkout" > change.fetch || echo no command'
 git submodule foreach 'chmod +x change.fetch && ./change.fetch || echo no fetch'
+git submodule foreach 'git log -n 1 || echo no log'
 git submodule foreach 'bazel clean --expunge && bazel build $name || echo no standalone'
 git submodule foreach 'bazel test //... || echo no tests'
 git submodule foreach 'rm change.json change.fetch && git checkout stable-2.14 || echo no files'

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ git submodule foreach 'curl -s -o change.json https://gerrit-review.googlesource
 git submodule foreach 'tail --lines=+2 change.json | jq -r ".[0].revisions[].fetch.http.commands.Checkout" > change.fetch || echo no command'
 git submodule foreach 'chmod +x change.fetch && ./change.fetch || echo no fetch'
 git submodule foreach 'bazel clean --expunge && bazel build $name || echo no standalone'
-git submodule foreach 'bazel test //... || echo no standalone'
-git submodule foreach 'rm change.json change.fetch && git checkout stable-2.14'
+git submodule foreach 'bazel test //... || echo no tests'
+git submodule foreach 'rm change.json change.fetch && git checkout stable-2.14 || echo no files'
 ```
 
 ## Review bazlets upgrade change

--- a/README.md
+++ b/README.md
@@ -49,3 +49,10 @@ git submodule foreach 'bazel test //... || echo no standalone'
 git submodule foreach 'rm change.json change.fetch && git checkout stable-2.14'
 ```
 
+## Review bazlets upgrade change
+### -works with trailing commands above
+
+```
+git submodule foreach 'curl -s -o change.json https://gerrit-review.googlesource.com/changes/?q=project:plugins/$name+status:open+branch:stable-2.14+Upgrade+bazlets\&n=1\&o=CURRENT_REVISION\&o=DOWNLOAD_COMMANDS || echo no change'
+```
+


### PR DESCRIPTION
This PR was checked as not containing any submodule changes, so (should be) made of only trivial file changes from the merge-up. The merge commit in this PR ends with this clarification, repeated here solely for informational purposes:

Adapt README.md from stable-2.16 to master branch usage, as is, despite some lines becoming less relevant (master being the default branch). Do so mainly for consistency purposes across gerrit-plugin branch versions of the README.

This PR brings a few changed (and new) files from the merge-up, as master in gerrit-plugins has been recently behind the stable branches.