### PR TITLE
Add reviewassistant plugin which is now buildable with 2.16

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -76,3 +76,6 @@
 [submodule "batch"]
 	path = batch
 	url = https://gerrit-review.googlesource.com/plugins/batch
+[submodule "reviewassistant"]
+	path = reviewassistant
+	url = https://gerrit-review.googlesource.com/plugins/reviewassistant


### PR DESCRIPTION
I thought of not adding it to stable-2.15, even though it was previously building with it.