### PR TITLE
Remove the currently git-ignored force-draft directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 # LC_COLLATE=C sort
-/force-draft
 /.idea/
 /gerrit-plugins.iml


### PR DESCRIPTION
For git status to tell the whole truth about potential paths confusion.