### PR TITLE
Remove all the currently git-ignored plugin directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 # LC_COLLATE=C sort
-/batch
-/task
 /.idea/
 /gerrit-plugins.iml


### PR DESCRIPTION
For git status to tell the whole truth about potential paths confusion.