### PR TITLE
Bulk: Add query option support to matching changes

### DIFF
--- a/bulk.py
+++ b/bulk.py
@@ -18,6 +18,9 @@ def _main():
     parser.add_argument('-q', '--query', dest='query',
                         required=True, action='store',
                         help='query')
+    parser.add_argument('-o', '--option', dest='options',
+                        required=False, action='append',
+                        help='query options')
     parser.add_argument('-a', '--approve', dest='approve',
                         required=False, action='store_true',
                         help='apply Code-Review+2 to changes')
@@ -43,7 +46,10 @@ def _main():
 
     api = GerritRestAPI(url=options.url)
     query_terms = options.query.replace(" ", "%20")
-    changes = api.get("/changes/?q=" + query_terms)
+    uri = "/changes/?q=" + query_terms
+    for option in options.options:
+        uri = uri + "&o=" + option
+    changes = api.get(uri)
     if options.filter:
         changes = [c for c in changes
                    if c["project"].startswith(options.filter)]


### PR DESCRIPTION
Support the passing of none, one or many Gerrit API query options (-o).

For example, calling the script with [1] below adds download commands
within every matching change's current revision key value structure.

This can be a first step into amending the script further for more bulk
commands, such as locally fetching changes for automated verification.

[1] -q owner:self+status:open -o CURRENT_REVISION -o DOWNLOAD_COMMANDS